### PR TITLE
Front-end Developer description update.

### DIFF
--- a/source/jobs/front-end-developer.html.erb
+++ b/source/jobs/front-end-developer.html.erb
@@ -8,73 +8,35 @@ job_title: Front-end Developer
 <section class="section section_column section_column_banner">
   <div class="banner_container">
     <h1 class="heading heading_section"><%= current_page.data.job_title %></h1>
-    <p class="paragraph_intro">At Abletech we build web + mobile solutions. We’re innovative with both our in-house products and for our clients.</p>
-    <p class="paragraph_intro">We are looking for a competent Front-end Developer.</p>
+    <p class="paragraph_intro">At Abletech we love building for The Web™. We are looking for an experienced Front-end Developer who does too.</p>
   </div>
 </section>
 
 <section class="section section_column">
 
-  <h2 class="heading heading_subsection">Snapshot of the work we’re doing</h2>
+	<h2 class="heading heading_subsection">What experience do you need?</h2>
+	<p>Ideally, you should have many years of experience as a Front-end Developer. If not, do you like working with HTML and CSS?</p>
+	<p>You <em>should</em> have:</p>
+	<ul>
+		<li>great HTML and CSS skills</li>
+		<li>demonstrable experience creating cross-browser and mobile compatible websites (<abbr title="Responseive Web Design">RWD</abbr>, Mobile First, etc)</li>
+		<li>a good understanding of templating systems</li>
+		<li>experience working with distributed version control systems such as Git and GitHub</li>
+		<li>some JavaScript/jQuery experience</li>
+	</ul>
+	<p>Bonus points if you have:</p>
+	<ul>
+		<li>a good understanding of Web Accessibility</li>
+		<li>experience writing unobtrusive JavaScript</li>
+		<li>some understanding of Web Performance Optimisations</li>
+		<li>experience creating Pattern Libraries and Styleguides.</li>
+	</ul>
 
-  <p>Building and growing our own SaaS businesses</p>
-  <ul>
-    <li>Understanding customer needs</li>
-    <li>Identifying new opportunities</li>
-    <li>Strategic moves into new markets or sectors</li>
-    <li><a href="https://addressfinder.nz">AddressFinder.nz</a> and <a href="http://watchmygear.com">WatchMyGear.com</a></li>
-  </ul>
+	<h2 class="heading heading_subsection">What sort of work will you be doing?</h2>
+	<p>You’ll be spending most of your time working with our existing Front-end Developer, Shaun. Together you’ll be building web-based user interfaces for our clients, or enriching the front-end of our various in-house products, such as <a href="https://addressfinder.nz/">AddressFinder</a>. We like <a href="https://en.wikipedia.org/wiki/Pair_programming">Pair-Programming</a> here at Abletech, so it’ll be an opportunity to improve your skills, and make our front-end work even better.</p>
+	<p>The majority of the front-end work we do is in good old HTML and CSS, but that doesn’t mean we don’t get to dabble with fancy-pants JavaScript frameworks such as Angular and D3.</p>
+	<p>On the server side, we mainly work within Ruby-based frameworks such as Rails and Middleman, but we seem to be doing an increasing amount of work within the Node.js stack.</p>
 
-  <p>Helping our clients transform their businesses</p>
-  <ul>
-    <li>Modern approaches and ‘cloud’ technologies</li>
-    <li>Moving from a larger centralised technology stack to a set of distributed micro services</li>
-    <li>Increased pace of delivery by shipping smaller pieces more regularly</li>
-  </ul>
-
-  <h2 class="heading heading_subsection">How we work</h2>
-
-  <p>We have a commitment to code quality</p>
-  <ul>
-    <li>peer reviews</li>
-    <li>supporting tools such as Code Climate</li>
-    <li>monitoring test coverage with Travis CI</li>
-    <li>Rocket espresso machine == better code</li>
-  </ul>
-
-  <p>Continuous integration and delivery</p>
-  <ul>
-    <li>making deployment/shipping an everyday task</li>
-    <li>making it easy</li>
-  </ul>
-
-  <p>Continuous Improvement</p>
-  <ul>
-    <li><a href="http://blog.abletech.nz/post/113817462848/re-building-addressfinder-nz">Measuring and building fast front-ends</a></li>
-    <li>Mobile First and Progressive Enhancement</li>
-  </ul>
-
-  <p>Delighting the customer</p>
-  <ul>
-    <li>We listen to and understand the underlying problem or need, rather than just coding the solution that first appears</li>
-    <li>Collaborating with our customers by creating multi-role teams. Abletech technical staff collaborate with our clients to deliver a great result together</li>
-    <li>Due to the calibre of our team, and our proven track record, we’re very fortunate to be able to select the clients we work with</li>
-  </ul>
-
-  <h2 class="heading heading_subsection">The Abletech team</h2>
-
-  <p>Active within our community</p>
-  <ul>
-    <li>All attend RubyConf AU each year</li>
-    <li>Participate in Webstock, AWS Summit, Kiwicon, WDCNZ etc.</li>
-    <li>Committed to continuous learning</li>
-  </ul>
-
-  <p>Supporting Wellington</p>
-  <ul>
-    <li>Leading, speaking at and volunteering</li>
-    <li>Summer of Tech, Wellington Girls’ College, RailsGirls, WellRailed, Enspiral Dev Academy, Startup Weekend, Charity-IT Hackathon etc.</li>
-  </ul>
 </section>
 
 <section class="section section_column section_column_banner section_alternate">


### PR DESCRIPTION
Removed the Marketing Double-Speak from the Front-end Developer job description.
Replaced it with a more frank summary of the role and work experience required.