### PR TITLE
Fix path references for the headings in the blog content list

### DIFF
--- a/source/javascripts/_pages/home/page.home.blogPosts.js.coffee
+++ b/source/javascripts/_pages/home/page.home.blogPosts.js.coffee
@@ -27,7 +27,7 @@ class Abletech.BlogPosts
         firstP = snippet && snippet[0] || ''
         li = document.createElement('li')
         li.innerHTML = '\
-        <h2><a href="' + posts[i]['post_url'] + '">' + posts[i]['title'] + '</a></h2>\
+        <h2><a href="' + posts[i]['link'] + '">' + posts[i]['title'] + '</a></h2>\
         <p class="published-date">' + new Date(posts[i]['pubDate']).format('j F, Y') + '</p>\
         <div class="post-body">' + firstP + '</div>\
         <a href="' + posts[i]['link'] + '">Read more of ‘' + posts[i]['title'] + '’…</a>'


### PR DESCRIPTION
For: https://trello.com/c/Zm3EFays/1035-abletech-nz-blog-links-fault

This PR fixes the heading links for the featured articles from the blog.

cc @marcusbaguley 