### PR TITLE
Fix the regex for capturing the first paragraph in the blog content

### DIFF
--- a/source/javascripts/_pages/home/page.home.blogPosts.js.coffee
+++ b/source/javascripts/_pages/home/page.home.blogPosts.js.coffee
@@ -22,7 +22,7 @@ class Abletech.BlogPosts
 
       ul = @blogPosts.querySelector('.blog_posts')
       for i in [0..(Math.min(2, (posts.length - 1)))]
-        regex = new RegExp('(<p class=.medium-feed-snippet.>.*?</p>)')
+        regex = new RegExp('\<p.*?\<\/p\>')
         snippet = regex.exec(posts[i]['description'])
         firstP = snippet && snippet[0] || ''
         li = document.createElement('li')


### PR DESCRIPTION
Looks like Medium are no longer using classNames in their `content` or `description` return values.

cc @marcusbaguley 